### PR TITLE
Fixed issue #2 Cannot use empty string as a class name

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -79,7 +79,7 @@ class zip (
   }
 
   ### Include custom class if $my_class is set
-  if $zip::my_class {
+  if $zip::my_class and $zip::my_class != '' {
     include $zip::my_class
   }
 


### PR DESCRIPTION
Just added additional check for `$zip::my_class`.